### PR TITLE
Ensure .htaccess files are not over written by deployments

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -74,6 +74,9 @@
         "drupal-scaffold": {
             "locations": {
                 "web-root": "web/"
+            },
+            "file-mapping": {
+                "[web-root]/.htaccess": false
             }
         },
         "installer-paths": {


### PR DESCRIPTION
Fixes #48

Adds configuration to the Drupal Composer Scaffold to not over write .htaccess files.